### PR TITLE
python-lessons: fix 01 lesson for issue #7

### DIFF
--- a/python-lessons/01 - Introduction to Programming with Python.ipynb
+++ b/python-lessons/01 - Introduction to Programming with Python.ipynb
@@ -533,27 +533,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(1, 7, 38, 9, 0)\n"
+      "(1, 7, 38, 9, 0)\n",
+      "('strawberry', 'vanilla', 'chocolate')\n"
      ]
     }
    ],
    "source": [
     "coordinates = (1, 7, 38, 9, 0)\n",
-    "print (coordinates)"
+    "print (coordinates)\n",
+    "\n",
+    "icecream_flavors = (\"strawberry\", \"vanilla\", \"chocolate\")\n",
+    "print (icecream_flavors)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "... and any types of values."
+    "... and any types of values.\n",
+    "\n",
+    "Once created, you `cannot add more items to a tuple` (but you can add items to a list).  If we try to append, like we did with lists, we get an error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "icecream_flavors.append('bubblegum')"
    ]
   },
   {
@@ -561,6 +576,13 @@
    "metadata": {},
    "source": [
     "### FAQ: If tuples are like lists, why would I use a tuple instead of a list?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because you can't change them. For example: tuples are a good way to represent `input` data. Using tuples can help you avoid changing your original input data."
    ]
   },
   {
@@ -696,18 +718,7 @@
     "3. `\"900\"` : `\"key\"` : `\"value\"`\n",
     "4. `Books` : `10000`\n",
     "\n",
-    "Post your answer the the EtherPad, or vote for an existing answer\n",
-    "\n",
-    "---\n",
-    "\n",
-    "icecream_flavors = (\"strawberry\", \"vanilla\", \"chocolate\")\n",
-    "print (icecream_flavors)\n",
-    "\n",
-    "Once created, you `cannot add more items to a tuple` (but you can add items to a list).  If we try to append, like we did with lists, we get an error\n",
-    "\n",
-    "icecream_flavors.append('bubblegum')\n",
-    "\n",
-    "Because you can't change them. For example: tuples are a good way to represent `input` data. Using tuples can help you avoid changing your original input data. "
+    "Post your answer to the EtherPad, or vote for an existing answer"
    ]
   },
   {


### PR DESCRIPTION
I believe that issue #7 is fixed. I'm not sure how the change was incorporated.  Looking at feb2018-python, the 01 lesson does not contain the FAQ.  Also the icecream tuple example was placed within a Markdown cell instead of a Code cell.